### PR TITLE
Fix: Resolve ReferenceError for checkCollision function.

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
 </head>
 <body>
     <canvas id="gameCanvas"></canvas>
+    <script src="js/utils.js"></script>
     <script src="js/projectile.js"></script>
     <script src="js/aiEnemy.js"></script>
     <script src="js/building.js"></script>

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,0 +1,18 @@
+function checkCollision(obj1, obj2) {
+    // Basic AABB collision detection
+    // Consider sprite width/height if available, otherwise use 'size'
+    const obj1Right = obj1.x + (obj1.frameWidth || obj1.width || obj1.size);
+    const obj1Bottom = obj1.y + (obj1.frameHeight || obj1.height || obj1.size);
+    const obj2Right = obj2.x + (obj2.frameWidth || obj2.width || obj2.size);
+    const obj2Bottom = obj2.y + (obj2.frameHeight || obj2.height || obj2.size);
+
+    if (obj1.x < obj2Right &&
+        obj1Right > obj2.x &&
+        obj1.y < obj2Bottom &&
+        obj1Bottom > obj2.y) {
+        // Collision detected
+        return true;
+    }
+    // No collision
+    return false;
+}


### PR DESCRIPTION
- I moved the `checkCollision` function from its previous location to a new utility file `js/utils.js`.
- I updated `index.html` to load `js/utils.js` as the first script, ensuring `checkCollision` is defined before any scripts that might use it.
- I verified that `checkCollision` is no longer present in other JavaScript files like `js/script.js` or `js/monster.js`.

This resolves the `Uncaught ReferenceError: checkCollision is not defined` that occurred after the initial refactoring of JavaScript classes.