### PR TITLE
Fix: Correct syntax errors after main menu implementation.

### DIFF
--- a/js/monster.js
+++ b/js/monster.js
@@ -275,8 +275,7 @@ class Monster {
                         this.setCurrentAnimation('idle');
                     }
                 } // If it was climbing and hit the ground, it might transition to idle/walk if no longer on building
-                }
-            }
+            } // This is the actual end of the if (this.y > gameHeight ...)
         } // End of main movement/climbing logic block
 
         this.updateAnimationFrame();

--- a/js/script.js
+++ b/js/script.js
@@ -679,10 +679,7 @@ function gameLoop() {
                         enemyProjectiles.splice(i, 1);
                     }
                 }
-                }
-            }
-        }
-    } // End of main 'playing' logic for updates
+    } // End of main 'playing' logic for updates (this closes the inner "if (gameState === 'playing')")
 
     // Drawing logic (should happen regardless of whether game just ended in this frame)
     for (const building of buildings) {


### PR DESCRIPTION
- Removed an extra closing brace in `js/monster.js` within the `update()` method's ground check logic. This was likely causing cascading parsing issues.
- Removed two extra closing braces in `js/script.js` within the `gameLoop()` function after the projectile update loop.

These changes address the `Uncaught SyntaxError` exceptions that occurred after the previous feature commit.